### PR TITLE
Stop sending mod punishments in arbitrary rooms

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -61,10 +61,9 @@ exports.parse = {
 
 		var spl = message.split('|');
 		if (!spl[1]) {
-			spl = message.split('>');
-			if (!spl[1])
-				return;
-			this.room = spl[1];
+			spl = spl[0].split('>');
+			if (spl[1]) this.room = spl[1];
+			return;
 		}
 
 		switch (spl[1]) {


### PR DESCRIPTION
Prevents `this.room` from potentially being set to an arbitrary string.
e.g. if `message = "Rightarrow was promoted to room voice by Some>one."`, `this.room = "one."`
