### PR TITLE
Fix message parsing and filter null characters

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * This is the file where commands get parsed
  *
  * Some parts of this code are taken from the Pokémon Showdown server code, so
@@ -44,17 +44,17 @@ exports.parse = {
 			}
 		}
 	},
-	message: function(message, connection) {
+	message: function(message, connection, lastMessage) {
 		if (!message) return;
 
 		if (message.indexOf('\n') > -1) {
 			var spl = message.split('\n');
-			for (var i = 0; i < spl.length; i++) {
+			for (var i = 0, len = spl.length; i < len; i++) {
 				if (spl[i].split('|')[1] && (spl[i].split('|')[1] === 'init' || spl[i].split('|')[1] === 'tournament')) {
 					this.room = '';
 					break;
 				}
-				this.message(spl[i], connection);
+				this.message(spl[i], connection, i === len - 1);
 			}
 			return;
 		}
@@ -62,9 +62,8 @@ exports.parse = {
 		var spl = message.split('|');
 		if (!spl[1]) {
 			spl = message.split('>');
-			if (!spl[1])
-				return;
-			this.room = spl[1];
+			if (spl[1]) this.room = spl[1];
+			return;
 		}
 
 		switch (spl[1]) {
@@ -188,11 +187,11 @@ exports.parse = {
 					function() {self.chatData = cleanChatData(self.chatData);},
 					30*60*1000
 				);
-				this.room = '';
+				if (lastMessage) this.room = '';
 				break;
 			case 'title':
 				ok('joined ' + spl[2]);
-				this.room = '';
+				if (lastMessage) this.room = '';
 				break;
 			case 'c':
 				var by = spl[2];
@@ -200,7 +199,7 @@ exports.parse = {
 				this.processChatData(by, this.room || 'lobby', connection, spl.join('|'));
 				if (this.room && this.isBlacklisted(toId(by), this.room)) this.say(connection, this.room, '/roomban ' + by + ', Blacklisted user');
 				this.chatMessage(spl.join('|'), by, this.room || 'lobby', connection);
-				this.room = '';
+				if (lastMessage) this.room = '';
 				break;
 			case 'c:':
 				var by = spl[3];
@@ -208,34 +207,34 @@ exports.parse = {
 				this.processChatData(by, this.room || 'lobby', connection, spl.join('|'));
 				if (this.room && this.isBlacklisted(toId(by), this.room)) this.say(connection, this.room, '/roomban ' + by + ', Blacklisted user');
 				this.chatMessage(spl.join('|'), by, this.room || 'lobby', connection);
-				this.room = '';
+				if (lastMessage) this.room = '';
 				break;
 			case 'pm':
 				var by = spl[2];
 				if (by.substr(1) === config.nick) return;
 				spl.splice(0, 4);
 				this.chatMessage(spl.join('|'), by, ',' + by, connection);
-				this.room = '';
+				if (lastMessage) this.room = '';
 				break;
 			case 'N':
 				var by = spl[2];
 				this.updateSeen(spl[3], spl[1], by);
 				if (toId(by) !== toId(config.nick) || ' +%@&#~'.indexOf(by.charAt(0)) === -1) return;
-				this.ranks[toId(this.room === '' ? 'lobby' : this.room)] = by.charAt(0);
-				this.room = '';
+				this.ranks[this.room || 'lobby'] = by.charAt(0);
+				if (lastMessage) this.room = '';
 				break;
 			case 'J': case 'j':
 				var by = spl[2];
 				if (this.room && this.isBlacklisted(toId(by), this.room)) this.say(connection, this.room, '/roomban ' + by + ', Blacklisted user');
-				this.updateSeen(by, spl[1], (this.room === '' ? 'lobby' : this.room));
+				this.updateSeen(by, spl[1], this.room || 'lobby');
 				if (toId(by) !== toId(config.nick) || ' +%@&#~'.indexOf(by.charAt(0)) === -1) return;
-				this.ranks[toId(this.room === '' ? 'lobby' : this.room)] = by.charAt(0);
-				this.room = '';
+				this.ranks[this.room || 'lobby'] = by.charAt(0);
+				if (lastMessage) this.room = '';
 				break;
 			case 'l': case 'L':
 				var by = spl[2];
-				this.updateSeen(by, spl[1], (this.room === '' ? 'lobby' : this.room));
-				this.room = '';
+				this.updateSeen(by, spl[1], this.room || 'lobby');
+				if (lastMessage) this.room = '';
 				break;
 		}
 	},
@@ -342,7 +341,7 @@ exports.parse = {
 		user = toId(user);
 		if (!user || room.charAt(0) === ',') return;
 		room = toId(room);
-		msg = msg.trim().replace(/ +/g, " "); // removes extra spaces so it doesn't trigger stretching
+		msg = msg.trim().replace(/[ \u0000\u200B-\u200F]+/g, " "); // removes extra spaces and null characters so messages that should trigger stretching do so
 		this.updateSeen(user, 'c', room);
 		var time = Date.now();
 		if (!this.chatData[user]) this.chatData[user] = {
@@ -489,7 +488,6 @@ exports.parse = {
 			if (writing) {
 				writePending = true;
 				return;
-
 			}
 			writing = true;
 			var data = JSON.stringify(this.settings);


### PR DESCRIPTION
Stop changing the room to '' before parsing the last message, so if multiple messages are received at once, they aren't handled as if they're coming from lobby.
