### PR TITLE
Fix typo in reload command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -61,7 +61,7 @@ exports.commands = {
 			}
 			else if (toId(arg) === 'parser') {
 				this.uncacheTree('./parser.js');
-				parser = require('./parser.js');
+				Parse = require('./parser.js').parse; 
 				this.say(con, room, 'Parser reloaded.');
 			}
 		} catch (e) {


### PR DESCRIPTION
I assumed the variables were declared by all the same case sensitivity / scheme, sorry.
