### PR TITLE
Proposing a fix for stripCommands

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,7 +87,7 @@ global.toId = function (text) {
 global.stripCommands = function (text) {
 	text = text.trim();
 	if (text.charAt(0) === '/') return '/' + text;
-	if (text.charAt(0) === '!' || /^>>>? /.test(text)) return ' ' + text;
+	if (text.charAt(0) === '!' || /^>>>? /.test(text)) return '!' + text;
 	return text;
 };
 


### PR DESCRIPTION
With the newer showdown mechanisms, even putting a space before a ! will cause the user to execute it anyways (found out when kota used a !logout on one of my bots).  Perhaps putting another character before it (like a !) could help?