### PR TITLE
Update 'updateSeen' for chatmessages

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -26,7 +26,9 @@ var settings;
 try {
 	settings = JSON.parse(fs.readFileSync('settings.json'));
 } catch (e) {} // file doesn't exist [yet]
-if (!Object.isObject(settings)) settings = {};
+//if (!Object.isObject(settings)) settings = {};
+//after removing require('sugar') from main.js, I lost the method Object.[stuff] and replaced it with:
+if(typeof settings !== object) settings = {};
 
 exports.parse = {
 	actionUrl: url.parse('https://play.pokemonshowdown.com/~~' + Config.serverid + '/action.php'),
@@ -180,7 +182,12 @@ exports.parse = {
 				if (this.isBlacklisted(user.id, room.id)) this.say(room, '/roomban ' + user.id + ', Blacklisted user');
 
 				spl = spl.slice(3).join('|');
-				if (!user.hasRank(room.id, '%')) this.processChatData(user.id, room.id, spl);
+				if (!user.hasRank(room.id, '%')) {
+					this.processChatData(user.id, room.id, spl);
+				}
+				else {
+					this.updateSeen(user.id, 'c', room.id);
+				}
 				this.chatMessage(spl, user, room);
 				break;
 			case 'c:':
@@ -191,7 +198,12 @@ exports.parse = {
 				if (this.isBlacklisted(user.id, room.id)) this.say(room, '/roomban ' + user.id + ', Blacklisted user');
 
 				spl = spl.slice(4).join('|');
-				if (!user.hasRank(room.id, '%')) this.processChatData(user.id, room.id, spl);
+				if (!user.hasRank(room.id, '%')) {
+					this.processChatData(user.id, room.id, spl);
+				}
+				else {
+					this.updateSeen(user.id, 'c', room.id);
+				}				
 				this.chatMessage(spl, user, room);
 				break;
 			case 'pm':


### PR DESCRIPTION
I added an extra `this.updateSeen(user.id, 'c', room.id);`   under `case 'c' `and `case 'c:` update chatData for those who are % and up and were previously 'ignored'.

As for `Object.isObject` method from sugarjs, i tried using `typeof` instead after that dependency (from main.js) and it worked.

I didn't find any other things that i needed to change after not using sugar.   

Sadly, I'm not as good as what you may believe; I'm a music student that has an interest in coding.   I'm unable to try write a gulp script as of now.

I've mostly been working on a 4 month old of the boTTT, adding few features and fixing some things (like recognizing the bot's own rank in a room which didnt work when i downloaded the file) as well as making a 'Resource monitor' that identifies anyone spamming commands and saturating the buffer for `send(str)` as well as making +addcom (and a shit ton of games), +addcom being at the request of leagues and the games from THA (rip Briyella).  
If you'd like to see, I'd be honoured to show you my c9 workspace; but yeah, I'm not really a programmer